### PR TITLE
Add animated back-to-top button for smoother navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,5 +64,6 @@
   <footer class="section">
     <p>&copy; 2024 Akobir Ismatov</p>
   </footer>
+  <button id="back-to-top" aria-label="Back to top">↑</button>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -38,6 +38,18 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }, { threshold: 0.5 });
   sections.forEach(section => sectionObserver.observe(section));
+
+  const backToTop = document.getElementById('back-to-top');
+  window.addEventListener('scroll', () => {
+    if (window.scrollY > 300) {
+      backToTop.classList.add('show');
+    } else {
+      backToTop.classList.remove('show');
+    }
+  });
+  backToTop.addEventListener('click', () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  });
 });
 
 function populate(data) {

--- a/style.css
+++ b/style.css
@@ -116,6 +116,34 @@ body.dark .section:nth-of-type(odd) {
   animation: blink-cursor 0.8s steps(2, start) infinite;
 }
 
+#back-to-top {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  width: 3rem;
+  height: 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  background: var(--accent-color);
+  color: #fff;
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+#back-to-top.show {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+#back-to-top:hover {
+  transform: scale(1.1);
+}
+
 @keyframes blink-cursor {
   from { border-right-color: var(--accent-color); }
   to { border-right-color: transparent; }
@@ -128,5 +156,11 @@ body.dark .section:nth-of-type(odd) {
   }
   .skill-list {
     columns: 1;
+  }
+  #back-to-top {
+    bottom: 1rem;
+    right: 1rem;
+    width: 2.5rem;
+    height: 2.5rem;
   }
 }


### PR DESCRIPTION
## Summary
- Add floating back-to-top button to index for quick navigation.
- Style button with fade and scale effects and responsive sizing.
- Use JavaScript to reveal button after scrolling and smooth-scroll to page top.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e5546f2c832aa8b31a80dca8cc75