### PR TITLE
Use profile image and relocate CV download link

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,14 +19,15 @@
       <li><a href="#projects">Projects</a></li>
       <li><a href="#achievements">Achievements</a></li>
       <li><a href="#contact">Contact</a></li>
+      <li><a href="assets/Akobir_Ismatov_CV.pdf" download>Download CV</a></li>
     </ul>
     <button id="theme-toggle" aria-label="Toggle dark mode">🌓</button>
   </nav>
 
   <header id="about" class="section">
+    <img src="ako.jpg" alt="Akobir Ismatov" class="profile-pic" />
     <h1 id="name"></h1>
     <p class="tagline" id="headline"></p>
-    <a class="btn" href="assets/Akobir_Ismatov_CV.pdf" download>Download CV (PDF)</a>
   </header>
 
   <section id="education" class="section">

--- a/style.css
+++ b/style.css
@@ -112,6 +112,15 @@ html, body {
   opacity: 0.9;
 }
 
+.profile-pic {
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  object-fit: cover;
+  display: block;
+  margin: 0 auto 1rem;
+}
+
 .tagline {
   display: inline-block;
   white-space: pre-wrap;


### PR DESCRIPTION
## Summary
- Display new profile photo in the header for a personal touch
- Move CV download link to navigation bar to declutter header
- Style profile image for consistent appearance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e95e414c832a85d58ef587668673