### PR TITLE
Add responsive mobile navigation menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
 <body>
   <nav class="navbar">
     <div class="logo">AI</div>
+    <button id="nav-toggle" aria-label="Toggle navigation">☰</button>
     <ul class="nav-links">
       <li><a href="#about">About</a></li>
       <li><a href="#education">Education</a></li>

--- a/script.js
+++ b/script.js
@@ -28,6 +28,15 @@ document.addEventListener('DOMContentLoaded', () => {
   sections.forEach(section => observer.observe(section));
 
   const navLinks = document.querySelectorAll('.nav-links a');
+  const navToggle = document.getElementById('nav-toggle');
+  const navLinksContainer = document.querySelector('.nav-links');
+  navToggle.addEventListener('click', () => {
+    navLinksContainer.classList.toggle('show');
+  });
+  navLinks.forEach(link =>
+    link.addEventListener('click', () => navLinksContainer.classList.remove('show'))
+  );
+
   const sectionObserver = new IntersectionObserver(entries => {
     entries.forEach(entry => {
       const id = entry.target.getAttribute('id');

--- a/style.css
+++ b/style.css
@@ -55,6 +55,13 @@ html, body {
   color: var(--accent-color);
   border-bottom: 2px solid var(--accent-color);
 }
+#nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
 #theme-toggle {
   cursor: pointer;
   background: none;
@@ -168,9 +175,26 @@ html, body {
 }
 
 @media (max-width: 600px) {
+  #nav-toggle {
+    display: block;
+  }
   .nav-links {
-    flex-wrap: wrap;
-    justify-content: center;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    flex-direction: column;
+    background: var(--bg-color);
+    gap: 0;
+    display: none;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  }
+  .nav-links.show {
+    display: flex;
+  }
+  .nav-links a {
+    padding: 0.75rem 1rem;
+    display: block;
   }
   .skill-list {
     columns: 1;


### PR DESCRIPTION
## Summary
- add hamburger toggle button to navbar for mobile
- style nav links as dropdown on small screens
- wire up JavaScript to open and close the mobile menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ea487b94832aac4b1e4a8f538ac1