### PR TITLE
Add scroll progress indicator to portfolio page

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <script defer src="script.js"></script>
 </head>
 <body>
+  <div id="progress-bar"></div>
   <nav class="navbar">
     <div class="logo">AI</div>
     <button id="nav-toggle" aria-label="Toggle navigation">☰</button>

--- a/script.js
+++ b/script.js
@@ -50,13 +50,19 @@ document.addEventListener('DOMContentLoaded', () => {
   sections.forEach(section => sectionObserver.observe(section));
 
   const backToTop = document.getElementById('back-to-top');
+  const progressBar = document.getElementById('progress-bar');
   window.addEventListener('scroll', () => {
+    const scrollTop = document.documentElement.scrollTop || document.body.scrollTop;
+    const scrollHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+    const scrolled = (scrollTop / scrollHeight) * 100;
+    progressBar.style.width = `${scrolled}%`;
     if (window.scrollY > 300) {
       backToTop.classList.add('show');
     } else {
       backToTop.classList.remove('show');
     }
   });
+  window.dispatchEvent(new Event('scroll'));
   backToTop.addEventListener('click', () => {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   });

--- a/style.css
+++ b/style.css
@@ -20,9 +20,20 @@ html, body {
   scroll-behavior: smooth;
 }
 
+#progress-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 4px;
+  width: 0;
+  background: var(--accent-color);
+  z-index: 2000;
+  transition: width 0.25s ease;
+}
+
 .navbar {
   position: sticky;
-  top: 0;
+  top: 4px;
   display: flex;
   justify-content: space-between;
   align-items: center;


### PR DESCRIPTION
## Summary
- add a scroll progress bar element and styles
- update script to fill the progress bar while scrolling and keep back-to-top behavior
- offset navbar to sit below the new progress indicator

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ec6618d0832a9c4dc1e5391601b0