### PR TITLE
Add faint code background animation to CV sections

### DIFF
--- a/script.js
+++ b/script.js
@@ -85,6 +85,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   initMatrix('matrix-left');
   initMatrix('matrix-right');
+  initCodeBackground();
 });
 
 function populate(data) {
@@ -225,4 +226,33 @@ function initMatrix(id) {
   window.addEventListener('resize', resize);
   resize();
   draw();
+}
+
+function initCodeBackground() {
+  const snippets = [
+    'const x = 42;',
+    'console.log("Hello, world!");',
+    'for (let i = 0; i < 10; i++) { }',
+    'if (value) {\n  doSomething();\n}',
+    'let sum = (a, b) => a + b;'
+  ];
+  document.querySelectorAll('.section').forEach(section => {
+    const bg = document.createElement('div');
+    bg.className = 'code-bg';
+    section.appendChild(bg);
+
+    function cycle() {
+      const snippet = snippets[Math.floor(Math.random() * snippets.length)];
+      bg.textContent = '';
+      bg.style.opacity = 0.05;
+      typeWriter(snippet, bg, 0, () => {
+        setTimeout(() => {
+          bg.style.opacity = 0;
+          setTimeout(cycle, 1000);
+        }, 2000);
+      });
+    }
+
+    cycle();
+  });
 }

--- a/style.css
+++ b/style.css
@@ -114,6 +114,28 @@ html, body {
   transform: perspective(800px) rotateX(var(--tiltY)) rotateY(var(--tiltX));
   transition: transform 0.2s ease;
   background: var(--section-alt-bg);
+  position: relative;
+  overflow: hidden;
+}
+
+.section > * {
+  position: relative;
+  z-index: 1;
+}
+
+.code-bg {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 100%;
+  font-family: monospace;
+  color: var(--accent-color);
+  opacity: 0;
+  pointer-events: none;
+  user-select: none;
+  text-align: center;
+  transition: opacity 1s ease;
 }
 
 .hidden {


### PR DESCRIPTION
## Summary
- Add `.code-bg` overlay and related CSS to animate faint background code
- Implement `initCodeBackground` to type random snippets with fade-out

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ee23954c832a921280afe3aac9f1