### PR TITLE
Slow matrix rain and widen canvases

### DIFF
--- a/script.js
+++ b/script.js
@@ -197,6 +197,7 @@ function initMatrix(id) {
   if (!canvas) return;
   const ctx = canvas.getContext('2d');
   const fontSize = 16;
+  const speed = 0.5;
   let columns = 0;
   let drops = [];
 
@@ -204,7 +205,7 @@ function initMatrix(id) {
     canvas.height = window.innerHeight;
     canvas.width = canvas.offsetWidth;
     columns = Math.floor(canvas.width / fontSize);
-    drops = Array(columns).fill(1);
+    drops = Array(columns).fill(0);
   }
 
   function draw() {
@@ -218,7 +219,7 @@ function initMatrix(id) {
       if (drops[i] * fontSize > canvas.height && Math.random() > 0.975) {
         drops[i] = 0;
       }
-      drops[i]++;
+      drops[i] += speed;
     }
     requestAnimationFrame(draw);
   }

--- a/style.css
+++ b/style.css
@@ -34,7 +34,7 @@ html, body {
 .matrix-canvas {
   position: fixed;
   top: 0;
-  width: 80px;
+  width: 160px;
   height: 100vh;
   pointer-events: none;
   z-index: 10;


### PR DESCRIPTION
## Summary
- Slow matrix animation by introducing speed control and lower drop increments.
- Double the width of matrix canvases for a wider side animation effect.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7eeffd778832aa58428ca43fabfd1