### PR TITLE
Add publications and certifications sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,8 @@
       <li><a href="#experience">Experience</a></li>
       <li><a href="#skills">Skills</a></li>
       <li><a href="#projects">Projects</a></li>
+      <li><a href="#publications">Publications</a></li>
+      <li><a href="#certifications">Certifications</a></li>
       <li><a href="#achievements">Achievements</a></li>
       <li><a href="#contact">Contact</a></li>
       <li><a href="assets/Akobir_Ismatov_CV.pdf" download>Download CV</a></li>
@@ -55,6 +57,16 @@
   <section id="projects" class="section">
     <h2>Projects</h2>
     <div id="projects-content"></div>
+  </section>
+
+  <section id="publications" class="section">
+    <h2>Publications</h2>
+    <ul id="publications-list"></ul>
+  </section>
+
+  <section id="certifications" class="section">
+    <h2>Certifications &amp; Training</h2>
+    <ul id="certifications-list"></ul>
   </section>
 
   <section id="achievements" class="section">

--- a/script.js
+++ b/script.js
@@ -126,7 +126,16 @@ function populate(data) {
   data.education.forEach(item => {
     const div = document.createElement('div');
     div.classList.add('entry');
-    div.innerHTML = `<h3>${item.degree}</h3><p>${item.institution} (${item.start_date} – ${item.end_date})</p>`;
+    div.innerHTML = `<h3>${item.degree}</h3><p>${item.institution} (${item.start_date} – ${item.end_date})</p><p>GPA: ${item.gpa}</p>`;
+    if (item.notes && item.notes.length) {
+      const ul = document.createElement('ul');
+      item.notes.forEach(n => {
+        const li = document.createElement('li');
+        li.textContent = n;
+        ul.appendChild(li);
+      });
+      div.appendChild(ul);
+    }
     edu.appendChild(div);
   });
 
@@ -151,6 +160,20 @@ function populate(data) {
       ul.appendChild(li);
     });
     projects.appendChild(ul);
+  });
+
+  const publications = document.getElementById('publications-list');
+  data.publications.forEach(pub => {
+    const li = document.createElement('li');
+    li.innerHTML = `<strong>${pub.title}</strong>, <em>${pub.venue}</em> (${pub.date})`;
+    publications.appendChild(li);
+  });
+
+  const certs = document.getElementById('certifications-list');
+  data.certifications_training.forEach(c => {
+    const li = document.createElement('li');
+    li.textContent = c;
+    certs.appendChild(li);
   });
 
   const achievements = document.getElementById('achievements-list');


### PR DESCRIPTION
## Summary
- Add navigation links and sections for publications and certifications
- Populate publications and certifications from CV JSON
- Display GPA and notes for each education entry

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ef9f3554832a8ef3104dae27ae27