### PR TITLE
Slow matrix animation and widen matrix canvas

### DIFF
--- a/script.js
+++ b/script.js
@@ -264,7 +264,7 @@ function initMatrix(id) {
   if (!canvas) return;
   const ctx = canvas.getContext('2d');
   const fontSize = 16;
-  const speed = 0.5;
+  const speed = 0.1;
   let columns = 0;
   let drops = [];
 

--- a/style.css
+++ b/style.css
@@ -31,14 +31,14 @@ html, body {
   transition: width 0.25s ease;
 }
 
-.matrix-canvas {
-  position: fixed;
-  top: 0;
-  width: 160px;
-  height: 100vh;
-  pointer-events: none;
-  z-index: 10;
-}
+  .matrix-canvas {
+    position: fixed;
+    top: 0;
+    width: 250px;
+    height: 100vh;
+    pointer-events: none;
+    z-index: 10;
+  }
 
 #matrix-left {
   left: 0;


### PR DESCRIPTION
## Summary
- Slow down Matrix-style background by reducing animation speed
- Widen Matrix canvas panels for increased visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f1616a5c832ab60f30fd442d0ef9