### PR TITLE
feat: add animated animal links in contact section

### DIFF
--- a/script.js
+++ b/script.js
@@ -28,6 +28,12 @@ const roleIcons = {
   'Lab Assistant': 'fa-solid fa-vials'
 };
 
+const profileAnimals = {
+  GitHub: '🐱',
+  LinkedIn: '🦊',
+  TryHackMe: '🐱‍💻'
+};
+
 function getSkillIcon(skill) {
   return skillIcons[skill] || 'fa-solid fa-circle';
 }
@@ -148,7 +154,8 @@ function populate(data) {
     <p>Location: ${data.contact.location}</p>
   `;
   data.contact.profiles.forEach(p => {
-    contact.innerHTML += `<p>${p.site}: <a href="${p.url}">${p.url}</a></p>`;
+    const animal = profileAnimals[p.site] || '🔗';
+    contact.innerHTML += `<p>${p.site}: <a href="${p.url}" class="animal-link" target="_blank" rel="noopener" aria-label="${p.site}">${animal}</a></p>`;
   });
 
   const skills = document.getElementById('skills-list');

--- a/style.css
+++ b/style.css
@@ -174,6 +174,25 @@ html, body {
   color: var(--accent-color);
 }
 
+#contact-content p {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.animal-link {
+  display: inline-block;
+  text-decoration: none;
+  font-size: 2rem;
+  color: inherit;
+  animation: bounce 2s infinite;
+}
+
+.animal-link:hover {
+  animation-play-state: paused;
+  transform: scale(1.2);
+}
+
 .btn {
   display: inline-block;
   background: var(--accent-color);
@@ -240,6 +259,11 @@ html, body {
   .matrix-canvas {
     display: none;
   }
+}
+
+@keyframes bounce {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-5px); }
 }
 
 @keyframes blink-cursor {


### PR DESCRIPTION
## Summary
- replace plain contact URLs with animated animal icons
- add bounce animation styles and mapping for each profile

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7f32d854c832a9ae655287f4ecb43