### PR TITLE
Fix TryHackMe profile URL

### DIFF
--- a/CV_info.json
+++ b/CV_info.json
@@ -9,7 +9,7 @@
     "profiles": [
       {"site": "GitHub", "url": "https://github.com/ATrublie"},
       {"site": "LinkedIn", "url": "https://www.linkedin.com/in/akobir-ismatov-ba9055195/"},
-      {"site": "TryHackMe", "url": "https://tryhackme.com/p/Yako bIA"}
+      {"site": "TryHackMe", "url": "https://tryhackme.com/p/YakobIA"}
     ]
   },
   "skills": [


### PR DESCRIPTION
## Summary
- correct TryHackMe profile link in CV information

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f4c2b898832a8c331f407933531a