### PR TITLE
Slow matrix animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -279,8 +279,8 @@ function initMatrix(id) {
   let columns = 0;
   let drops = [];
   let speeds = [];
-  const baseSpeed = 0.5;
-  const speedVariance = 1;
+  const baseSpeed = 0.1;
+  const speedVariance = 0.1;
 
   function resize() {
     canvas.height = window.innerHeight;


### PR DESCRIPTION
## Summary
- Decrease base matrix animation speed and variance to slow down falling characters

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f6d392e0832a89662cf24be29974