### PR TITLE
Animate contact icons on hover and add phone/email icons

### DIFF
--- a/script.js
+++ b/script.js
@@ -153,14 +153,16 @@ function populate(data) {
   });
 
   const contact = document.getElementById('contact-content');
+  const phoneIcon = '☎️';
+  const emailIcon = '✉️';
   contact.innerHTML = `
-    <p>Phone: <a href="tel:${data.contact.phone}">${data.contact.phone}</a></p>
-    <p>Email: <a href="mailto:${data.contact.email}">${data.contact.email}</a></p>
+    <p>Phone: <a href="tel:${data.contact.phone}" class="contact-icon" aria-label="Phone">${phoneIcon}</a></p>
+    <p>Email: <a href="mailto:${data.contact.email}" class="contact-icon" aria-label="Email">${emailIcon}</a></p>
     <p>Location: ${data.contact.location}</p>
   `;
   data.contact.profiles.forEach(p => {
     const animal = profileAnimals[p.site] || '🔗';
-    contact.innerHTML += `<p>${p.site}: <a href="${p.url}" class="animal-link" target="_blank" rel="noopener" aria-label="${p.site}">${animal}</a></p>`;
+    contact.innerHTML += `<p>${p.site}: <a href="${p.url}" class="contact-icon" target="_blank" rel="noopener" aria-label="${p.site}">${animal}</a></p>`;
   });
 
   const skills = document.getElementById('skills-list');

--- a/style.css
+++ b/style.css
@@ -178,17 +178,15 @@ html, body {
   gap: 0.5rem;
 }
 
-.animal-link {
+.contact-icon {
   display: inline-block;
   text-decoration: none;
   font-size: 2rem;
   color: inherit;
-  animation: bounce 2s infinite;
 }
 
-.animal-link:hover {
-  animation-play-state: paused;
-  transform: scale(1.2);
+.contact-icon:hover {
+  animation: bounce 0.6s infinite;
 }
 
 .btn {
@@ -272,8 +270,8 @@ html, body {
 }
 
 @keyframes bounce {
-  0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-5px); }
+  0%, 100% { transform: translateY(0) scale(1); }
+  50% { transform: translateY(-5px) scale(1.2); }
 }
 
 @keyframes blink-cursor {


### PR DESCRIPTION
## Summary
- Animate contact icons only on hover and integrate scale into bounce effect.
- Use bouncing icons for phone and email links alongside existing profile animals.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f7073d4c832a8dbb3e8b34d4a380